### PR TITLE
feat: develop/toggle 

### DIFF
--- a/src/layout/toggle_btn.js
+++ b/src/layout/toggle_btn.js
@@ -6,6 +6,7 @@ import product from "../images/package.png";
 
 const ToggleButton = () => {
   const navigate = useNavigate();
+  // 뒤로가기 클릭 시 toggle UI도 같이 변경되게 하기 위한 주소 상수로 설정
 
   // 새로고침 시에도 데이터 고정시키는 방법: localStorage
   // localStorage에는 숫자,array,bool형 모두 string으로 저장되므로 JSON stringify와 JSON parse를 해줘야 한다
@@ -31,6 +32,8 @@ const ToggleButton = () => {
       navigate("/manage/product");
     }
   }, [isRight]);
+
+  //토글이 닫혀있어도 해당 페이지가 화면에 보여지면 토글 오픈하는 useEffect
 
   return (
     <Container onClick={handleToggle}>

--- a/src/layout/toggle_btn.js
+++ b/src/layout/toggle_btn.js
@@ -5,30 +5,26 @@ import member from "../images/user.png";
 import product from "../images/package.png";
 
 const ToggleButton = () => {
-  /**
-   * TODOLIST
-   *
-   * [ 컴포넌트 구조 나누기에 대하여 생각해보기 ]
-   * - pagination props 전달 너무 많음
-   * - buttonArray 재사용 가능하게 깔끔하게 바꾸기
-   *
-   * - filter UI가 페이지네이션 버튼 클릭해야 적용이 되는 부분 고치기
-   *
-   * [ 뒤로가기 버튼 ]
-   * - pagination 뒤로가기 클릭 시 UI 변경 안 됨
-   * - toggle 뒤로가기 클릭 시 UI 변경 안 됨
-   *
-   */
-
   const navigate = useNavigate();
 
-  const [isRight, setIsRight] = useState(false);
+  // 새로고침 시에도 데이터 고정시키는 방법: localStorage
+  // localStorage에는 숫자,array,bool형 모두 string으로 저장되므로 JSON stringify와 JSON parse를 해줘야 한다
 
-  const toggleHandler = () => {
+  // toggle state
+  const [isRight, setIsRight] = useState(
+    localStorage.getItem("toggleState")
+      ? JSON.parse(localStorage.getItem("toggleState")) //로컬 스토리지에 toggleState라는 데이터가 저장되 있을때
+      : false // 없을 때 (첫 렌더링)
+  );
+
+  const handleToggle = () => {
     setIsRight(!isRight);
   };
 
   useEffect(() => {
+    //로컬스토리지에 데이터가 있다면 처음부터 isRight의 상태를 바꿔야함
+    localStorage.setItem("toggleState", JSON.stringify(isRight));
+
     if (isRight) {
       navigate("/manage/member");
     } else {
@@ -37,7 +33,7 @@ const ToggleButton = () => {
   }, [isRight]);
 
   return (
-    <Container onClick={toggleHandler}>
+    <Container onClick={handleToggle}>
       <Background className={` ${isRight ? "toggle--checked" : null}`}>
         <Toggle className={` ${isRight ? "toggle--checked" : null}`}>
           {isRight ? <img src={member} /> : <img src={product} />}

--- a/src/routes/router.js
+++ b/src/routes/router.js
@@ -4,6 +4,9 @@ import ManageMembers from "../pages/member";
 import ManageProducts from "../pages/product";
 import HomePage from "../pages/homepage/homepage";
 import RegisterMember from "../pages/member/register_member";
+import RegisterProduct from "../pages/product/register_product";
+import ProductList from "../pages/product/product_list";
+import MemberList from "../pages/member/member_list";
 
 const router = createBrowserRouter([
   { path: "/", element: <HomePage /> },
@@ -14,14 +17,31 @@ const router = createBrowserRouter([
       {
         path: "/manage/member",
         element: <ManageMembers />,
-      },
-      {
-        path: "/manage/register-member",
-        element: <RegisterMember />,
+        children: [
+          {
+            path: "/manage/member/list",
+            element: <MemberList />,
+          },
+          {
+            path: "/manage/member/register",
+            element: <RegisterMember />,
+          },
+        ],
       },
       {
         path: "/manage/product",
         element: <ManageProducts />,
+        children: [
+          {
+            path: "/manage/product/list",
+            element: <ProductList />,
+          },
+
+          {
+            path: "/manage/product/register",
+            element: <RegisterProduct />,
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
 [ todo ] 
새로고침 시 페이지와 toggle의 상태 등 데이터 유지 ✅
뒤로가기 ❌

toggle 버튼의 디자인도 뒤로가기 클릭 시 다른 데이터와 같이 변경되도록 (toggle의 isRight 상태도 같이 되돌아갈 수 있도록) 할 예정입니다.

- 이를 해결한 분의 코드를 참고 중 - 
`  const currentURL = window.location.href;
  const baseURL = "http://localhost:3000";
  //현재 url에서 baseURL과 파라미터를 제외한 주소만 가져오기
  const relativeURL = currentURL.replace(baseURL, "").split("?")[0];
`
useEffect를 사용하여 relativeURL 바뀔 때마다 현재 url과 각 페이지에 맵핑된 url이 일치하는 지를 확인하고, 일치한다면 해당 toggle을 열도록 로직을 짜셨는데 이를 어떻게 제 코드에 녹여내야할지 고민 중입니다.
